### PR TITLE
(QA-9666) Correct the order by (DESC)

### DIFF
--- a/src/main/resources/jnt_topRated/html/topRated.hidden.load.jsp
+++ b/src/main/resources/jnt_topRated/html/topRated.hidden.load.jsp
@@ -18,7 +18,7 @@
 <query:definition var="listQuery"
          statement="select * from [jmix:rating] as rating inner join [${currentNode.properties['j:typeOfContent'].string}] as rated on issamenode(rating,rated)
              where rating.[j:nbOfVotes] > ${currentNode.properties['j:minNbOfVotes'].long}
-             order by rating.[j:sumOfVotes] asc"/>
+             order by rating.[j:sumOfVotes] desc"/>
 <c:set target="${moduleMap}" property="editable" value="false" />
 <c:set target="${moduleMap}" property="listQuery" value="${listQuery}" />
 


### PR DESCRIPTION
'desc' (instead of 'asc') needed in the query to retrieve Top rated on top.
Rem: query made on 'sumOfVotes' can also lead to wrong results (example: a lot of voters put a very bad evaluation on an article...)